### PR TITLE
Remove ia_archiver from robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,1 @@
 # robotstxt.org/
-
-User-agent: ia_archiver
-Disallow: /


### PR DESCRIPTION
Currently we disallow ia_archiver as User-Agent. Thus we exclude Internet Archive's Waybackmachine to crawl our website. I would argue, that this project should be supported, not discouraged.

Furthermore, we rarely publish information (such as PII) that should not be archived. If this case comes up, we could ask IA to remove such information from the archives.

Also, they don't respect robots.txt's contents…

  https://web.archive.org/web/*/https://cultivation.space/*